### PR TITLE
This will ignore messages that contain a mentioned user.

### DIFF
--- a/cogs/search.py
+++ b/cogs/search.py
@@ -176,6 +176,9 @@ class Search(commands.Cog):
     async def on_message(self, message):
         if message.author.bot:
             return
+        discord_user_id_regex = "<@.?[0-9]*?>"
+        if re.search(discord_user_id_regex, message.content):
+            return
         string = r"{]<"
         if not any(elem in message.clean_content for elem in string):
             return


### PR DESCRIPTION
Many times we mention a user in our server the manual way while we are in mod channels ex: <@User ID> and this will trigger the bot to start typing and react to the message with an X

This little regex search will make sure that these cases are ignored.